### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/dfs_pruning.rs
+++ b/src/dfs_pruning.rs
@@ -173,7 +173,7 @@ pub mod statistics {
             writeln!(f, "")?;
             writeln!(
                 f,
-                "Seen:    {} ({:0.}/sec)",
+                "Seen:    {} ({:0}/sec)",
                 self.seen.separate_with_underscores(),
                 self.seen_per_second().separate_with_underscores()
             )?;


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.